### PR TITLE
Update mx-tools-desktop_pt_BR.po

### DIFF
--- a/translations-desktop-file/po/mx-tools-desktop_pt_BR.po
+++ b/translations-desktop-file/po/mx-tools-desktop_pt_BR.po
@@ -24,7 +24,7 @@ msgstr ""
 #. The desktop entry name will be displayed within the menu.
 #: desktop-in/mx-tools.desktop.in:4
 msgid "MX Tools"
-msgstr "Ferramentas de Configurações do MX"
+msgstr "Ferramentas do MX"
 
 #. # The desktop entry comment will be shown within the menu.
 #: desktop-in/mx-tools.desktop.in:6


### PR DESCRIPTION
The description in Brazilian Portuguese is too large and makes the menu bigger than usual on XFCE. The proposed change corrects that and also gives a more faithful translation.